### PR TITLE
Mocking attributes for cell component

### DIFF
--- a/src/components/Cell.test.jsx
+++ b/src/components/Cell.test.jsx
@@ -1,34 +1,19 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import Cell from "./Cell";
 
-function cellStatus_unselected() {
-  return "unselected";
-}
+// Create a mock function for cellStatus
+const cellStatusMock = vi.fn();
+const cellClickMock = vi.fn();
 
-function cellStatus_challenge() {
-  return "blue";
-}
-
-function cellStatus_correct() {
-  return "correct";
-}
-
-function cellStatus_incorrect() {
-  return "incorrect";
-}
-
-function cellClick() {
-  return "true";
-}
-
+// Test for rendering the Cell component when unselected
 describe("Renders the Cell component when unselected", () => {
   it("renders a cell", () => {
     render(
       <Cell
         cellValue={1}
-        cellStatus={() => cellStatus_unselected()}
-        onClick={() => cellClick}
+        cellStatus={() => cellStatusMock.mockReturnValue("unselected").apply()}
+        onClick={() => cellClickMock}
       />
     );
 
@@ -38,13 +23,14 @@ describe("Renders the Cell component when unselected", () => {
   });
 });
 
+// Test for rendering the Cell component when the cell is part of the challenge
 describe("Renders the Cell component when it is part of challenge", () => {
   it("renders a cell", () => {
     render(
       <Cell
         cellValue={1}
-        cellStatus={() => cellStatus_challenge()}
-        onClick={() => cellClick}
+        cellStatus={() => cellStatusMock.mockReturnValue("blue").apply()}
+        onClick={() => cellClickMock}
       />
     );
 
@@ -54,13 +40,14 @@ describe("Renders the Cell component when it is part of challenge", () => {
   });
 });
 
+// Test for rendering the Cell component when correctly selected
 describe("Renders the Cell component when correctly selected", () => {
   it("renders a cell", () => {
     render(
       <Cell
         cellValue={2}
-        cellStatus={() => cellStatus_correct()}
-        onClick={() => cellClick}
+        cellStatus={() => cellStatusMock.mockReturnValue("correct").apply()}
+        onClick={() => cellClickMock}
       />
     );
 
@@ -70,13 +57,14 @@ describe("Renders the Cell component when correctly selected", () => {
   });
 });
 
+// Test for rendering the Cell component when incorrectly selected
 describe("Renders the Cell component when incorrectly selected", () => {
   it("renders a cell", () => {
     render(
       <Cell
         cellValue={3}
-        cellStatus={() => cellStatus_incorrect()}
-        onClick={() => cellClick}
+        cellStatus={() => cellStatusMock.mockReturnValue("incorrect").apply()}
+        onClick={() => cellClickMock}
       />
     );
 


### PR DESCRIPTION
Mocking attributes for the cell component

Partially address #29 [Vitest Should Do a Better Job of Mocking Components](https://github.com/robertcrockett/memory-react/issues/29)