### PR TITLE
Moved swc loader to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@vitejs/plugin-react-swc": "^3.5.0",
     "jsdom": "^23.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -23,12 +22,12 @@
     "@testing-library/react": "^14.1.2",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
-    "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "vite": "^5.0.11",
+    "@vitejs/plugin-react-swc": "^3.5.0",
     "vitest": "^1.2.1",
     "@vitest/coverage-v8": "^1.2.1",
     "@vitest/ui": "^1.2.1"


### PR DESCRIPTION
Moved the @vitejs/plugin-react-swc library to devDependencies based on research.

Removed the @vitejs/plugin-react library altogether since babel is not being used here.