### PR TITLE
ESLint Ignore Patterns

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,12 +9,12 @@ export default [
     ...js.configs.recommended,
     ignores: [
       '!.*',
-      '**/assets/.*',
-      '**/node_modules/.*',
-      '**/dist/.*',
-      '**/coverage/.*',
+      '**/assets/**',
+      '**/node_modules/**',
+      '**/dist/**',
+      './coverage/**',
       '*.json',
-      '**/.git/.*'
+      '**/.git/**'
     ],
     rules: {
       "no-console": "warn", // Warns about console.log statements


### PR DESCRIPTION
Updating the ignores section to ignore all subdirectories and files within the dist directory. Coverage directory is now from the root directory.