### PR TITLE
useCountdown Unit Test

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
-    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.3.12",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "@vitest/coverage-v8": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.3.12",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "@vitest/coverage-v8": "^2.1.4",

--- a/src/hooks/useCountdown.test.js
+++ b/src/hooks/useCountdown.test.js
@@ -1,5 +1,5 @@
 // useCountdown.test.js
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react'
 import { act } from 'react';
 import { expect, it, describe, beforeEach, afterEach } from 'vitest';
 import useCountdown from './useCountdown';

--- a/src/hooks/useCountdown.test.js
+++ b/src/hooks/useCountdown.test.js
@@ -1,0 +1,46 @@
+// useCountdown.test.js
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react';
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import useCountdown from './useCountdown';
+
+describe('useCountdown', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should initialize with the initial value', () => {
+        const { result } = renderHook(() => useCountdown(10));
+        expect(result.current).toBe(10);
+    });
+
+    it('should decrement the countdown value every second', () => {
+        const { result } = renderHook(() => useCountdown(10));
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(result.current).toBe(9);
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(result.current).toBe(8);
+    });
+
+    it('should clear the interval when the component is unmounted', () => {
+        const { result, unmount } = renderHook(() => useCountdown(10));
+
+        unmount();
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+
+        expect(result.current).toBe(10); // Countdown should not decrement after unmount
+    });
+});


### PR DESCRIPTION
Adding unit tests for the useCountdown hook. Replacing the @testing-library/react-hooks import with the render hook from @testing-library/react for use with React 18 and greater.

Resolves the breakage of previous unit tests.
Closes #150